### PR TITLE
fix: Correct OpenXML type strings for alpha bullet styles

### DIFF
--- a/src/utils/pptxGenerator.ts
+++ b/src/utils/pptxGenerator.ts
@@ -643,8 +643,8 @@ function createSlideXml(question: string, slideNumber: number, duration: number 
   let bulletXml = '<a:buAutoNum type="arabicPeriod"/>'; // Default
   if (ombeaConfig?.answersBulletStyle) {
     switch (ombeaConfig.answersBulletStyle) {
-      case 'ppBulletAlphaUCParenRight': bulletXml = '<a:buAutoNum type="alphaUCParenR"/>'; break;
-      case 'ppBulletAlphaUCPeriod': bulletXml = '<a:buAutoNum type="alphaUCPeriod"/>'; break;
+      case 'ppBulletAlphaUCParenRight': bulletXml = '<a:buAutoNum type="alphaUcParenR"/>'; break;
+      case 'ppBulletAlphaUCPeriod': bulletXml = '<a:buAutoNum type="alphaUcPeriod"/>'; break;
       // ppBulletAlphaLCParenRight case REMOVED
       // ppBulletAlphaLCPeriod case REMOVED
       case 'ppBulletArabicParenRight': bulletXml = '<a:buAutoNum type="arabicParenR"/>'; break;


### PR DESCRIPTION
This commit fixes an issue where selecting "A.-J." (ppBulletAlphaUCPeriod) or "A)-J)" (ppBulletAlphaUCParenRight) bullet styles would result in incorrect rendering (e.g., as "(a)") and potential PPTX file corruption.

The issue was caused by incorrect casing in the OpenXML `type` attributes for these bullet styles within the `createSlideXml` function. The research confirmed the correct types use a lowercase 'c' in 'Uc'.

The following corrections were made in `src/utils/pptxGenerator.ts`:
- For `ppBulletAlphaUCPeriod`: changed type from "alphaUCPeriod" to "alphaUcPeriod".
- For `ppBulletAlphaUCParenRight`: changed type from "alphaUCParenR" to "alphaUcParenR".

These changes should ensure the correct visual rendering of these bullet styles and prevent file corruption associated with these specific options.